### PR TITLE
1.0.1

### DIFF
--- a/MergeAccountingClient/model_utils.py
+++ b/MergeAccountingClient/model_utils.py
@@ -1484,6 +1484,9 @@ def model_to_dict(model_instance, serialize=True):
         serialize (bool): if True, the keys in the dict will be values from
             attribute_map
     """
+    if isinstance(model_instance, dict):
+        return model_instance
+
     result = {}
 
     model_instances = [model_instance]


### PR DESCRIPTION
## Description of the change

minor fix, printing the output of certain models reveals that the existing code has an issue when they contain raw `dict`s:

https://github.com/OpenAPITools/openapi-generator/issues/10564

```
    def test_invoices_list(self):
        configuration = MergeAccountingClient.Configuration()

        # Swap YOUR_API_KEY below with your production key from:
        # https://app.merge.dev/configuration/keys
        configuration.api_key['tokenAuth'] = 'REDACTED'
        configuration.api_key_prefix['tokenAuth'] = 'Bearer'

        api_client = MergeAccountingClient.ApiClient(configuration)

        invoices_api_instance = InvoicesApi(api_client)

        # The string 'TEST_ACCOUNT_TOKEN' below works to test your connection
        # to Merge and will return dummy data in the response.
        # In production, replace this with account_token from user.

        x_account_token = 'REDACTED'

        try:
            api_response = invoices_api_instance.invoices_list(x_account_token)
            pprint.pprint(api_response)     # <------ this broke with the same stack trace from the github issue link above
        except MergeAccountingClient.ApiException as e:
            print('Exception when calling InvoicesApi->invoices_list: %s' % e)
```

The code change in this pr resolved it.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.
